### PR TITLE
feat: implement uwp ioc support with property injection for xaml pages

### DIFF
--- a/Yugen.Toolkit.Uwp/Hosting/Attributes/DependencyAttribute.cs
+++ b/Yugen.Toolkit.Uwp/Hosting/Attributes/DependencyAttribute.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Yugen.Toolkit.Uwp.Hosting.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+    public sealed class DependencyAttribute : Attribute
+    {
+    }
+}

--- a/Yugen.Toolkit.Uwp/Hosting/Attributes/ViewModelAttribute.cs
+++ b/Yugen.Toolkit.Uwp/Hosting/Attributes/ViewModelAttribute.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Yugen.Toolkit.Uwp.Hosting.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+    public sealed class ViewModelAttribute : Attribute
+    {
+    }
+}

--- a/Yugen.Toolkit.Uwp/Hosting/Host.cs
+++ b/Yugen.Toolkit.Uwp/Hosting/Host.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Windows.UI.Xaml.Controls;
+
+namespace Yugen.Toolkit.Uwp.Hosting
+{
+    public sealed class Host
+    {
+        public IServiceProvider ServicesContainer { get; }
+
+        public Frame RootFrame { get; private set; }
+
+        public Host(IServiceProvider servicesContainer)
+        {
+            this.ServicesContainer = servicesContainer ?? throw new ArgumentNullException(nameof(servicesContainer));
+        }
+
+        public Frame CreateNewHostedUwpFrame()
+        {
+            var newFrame = new IoCFrame(this.ServicesContainer);
+
+            this.RootFrame = newFrame;
+            return this.RootFrame;
+        }
+    }
+}

--- a/Yugen.Toolkit.Uwp/Hosting/IoCFrame.cs
+++ b/Yugen.Toolkit.Uwp/Hosting/IoCFrame.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Navigation;
+using Yugen.Toolkit.Uwp.Hosting.Attributes;
+
+namespace Yugen.Toolkit.Uwp.Hosting
+{
+    public sealed class IoCFrame : Frame
+    {
+        private readonly IServiceProvider serviceProvider;
+
+        public IoCFrame(IServiceProvider serviceProvider)
+        {
+            this.serviceProvider = serviceProvider ??
+                                     throw new ArgumentNullException(nameof(serviceProvider));
+
+            this.Navigated += OnFrameNavigated;
+        }
+
+        private void OnFrameNavigated(object sender, NavigationEventArgs e)
+        {
+            InjectViewModelIfRequired(e);
+            InjectProperties(e);
+        }
+
+        private void InjectViewModelIfRequired(NavigationEventArgs e)
+        {
+            var viewModelProperty = e.SourcePageType
+                            .GetProperties()
+                            .SingleOrDefault(prop => prop.GetCustomAttribute<ViewModelAttribute>() != null);
+
+            if (viewModelProperty != null)
+            {
+                var viewModelInstance = CreateInstance(viewModelProperty.PropertyType);
+                viewModelProperty.SetValue(e.Content, viewModelInstance);
+            }
+        }
+
+        private void InjectProperties(NavigationEventArgs e)
+        {
+            var injectableProperties = e.SourcePageType
+                .GetProperties()
+                .Where(prop => prop.GetCustomAttribute<DependencyAttribute>() != null)
+                .ToList();
+
+            if (!injectableProperties.Any())
+                return;
+
+            foreach (var injectableProperty in injectableProperties)
+            {
+                var injectablePropertyValue = this.serviceProvider.GetService(injectableProperty.PropertyType);
+                injectableProperty.SetValue(e.Content, injectablePropertyValue);
+            }
+        }
+
+        private object CreateInstance(Type instanceType)
+        {
+            var ctors = instanceType.GetConstructors();
+            var ctorsAndParameters = ctors
+                .Select(ctor => new { Ctor = ctor, Params = ctor.GetParameters() })
+                .OrderByDescending(a => a.Params.Length)
+                .ToList();
+
+            if (!ctorsAndParameters.Any())
+                return Activator.CreateInstance(instanceType);
+
+            foreach (var ctorAndParams in ctorsAndParameters)
+            {
+                var ctorParamsInstances = new List<object>(ctorAndParams.Params.Length);
+
+                try
+                {
+                    foreach (var ctorParam in ctorAndParams.Params)
+                    {
+                        var initializedCtorParam = this.serviceProvider.GetService(ctorParam.ParameterType);
+                        ctorParamsInstances.Add(initializedCtorParam);
+                    }
+
+                    return Activator.CreateInstance(instanceType, ctorParamsInstances.ToArray());
+                }
+                catch
+                {
+                    continue;
+                }
+            }
+
+            throw new Exception($"Unable to initialize instance of type: {instanceType.FullName}. Possible cause: no appropriate constructors were found.");
+        }
+    }
+}

--- a/Yugen.Toolkit.Uwp/Yugen.Toolkit.Uwp.csproj
+++ b/Yugen.Toolkit.Uwp/Yugen.Toolkit.Uwp.csproj
@@ -119,6 +119,10 @@
     <Compile Include="Handlers\BarcodeHandler.cs" />
     <Compile Include="Helpers\DebugVisibilityHelper.cs" />
     <Compile Include="Helpers\ControlHelper.cs" />
+    <Compile Include="Hosting\Attributes\DependencyAttribute.cs" />
+    <Compile Include="Hosting\Attributes\ViewModelAttribute.cs" />
+    <Compile Include="Hosting\Host.cs" />
+    <Compile Include="Hosting\IoCFrame.cs" />
     <Compile Include="Listeners\DependencyPropertyListener.cs" />
     <Compile Include="Services\CacheService.cs" />
     <Compile Include="Converters\ComboBoxConverter.cs" />


### PR DESCRIPTION
Brings support for dependency injection in UWP XAML pages. This is done using the Property Injection approach because I can't take control of initializing pages so I can't bring in constructor injection like MVC does for example.